### PR TITLE
change delete bind to be more specific

### DIFF
--- a/web/static/js/project_email_recipient.js
+++ b/web/static/js/project_email_recipient.js
@@ -33,7 +33,7 @@ function addRecipientToDisplay(emailRecipient){
                                  `data-email-recipient-id="${emailRecipient.id}">` +
                                  'Delete</a>' +
                                  '</li>')
-    bindDeleteButtons(recipientsContainer().find("li:last"))
+    bindDeleteButtons(recipientsContainer().find(".delete_recipient"))
 }
 
 


### PR DESCRIPTION
The behaviour of `recipientsContainer().find("li:last")` was resulting in the actual `<li>` element to have the delete event attached to it. This change makes the binding more specific to the delete button itself.
